### PR TITLE
remove sensitive data from code

### DIFF
--- a/student-services/.gitignore
+++ b/student-services/.gitignore
@@ -23,3 +23,4 @@
 /dist/
 /nbdist/
 /.nb-gradle/
+/config/

--- a/student-services/src/main/resources/application.properties
+++ b/student-services/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 spring.datasource.url= jdbc:postgresql://localhost:5432/borsa
-spring.datasource.username=postgres
-spring.datasource.password=H545G1212
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.mvc.view.prefix: /WEB-INF/jsp/


### PR DESCRIPTION
In real software world developers should not keep sensitive data (usernames, passwords, credit card numbers, etc.)  into their code. You can add config folder in your project home (I have excluded it from the sources so it will not be tracked in GitHub) and place there your sensitive data configuration. For instance place in `config/application.properties` file following two entries:
```
spring.datasource.username=postgres
spring.datasource.password=H545G1212
```
Moreover when going in production or other environment (not your local one) these parameters will differ for sure. You need a way to specify them for the target environment. This way of configuring is very easy and keeps target environment setting separate from the code